### PR TITLE
Keybindings for movement keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "rs_snake"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs_snake"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "The classic 'Snake' game as a terminal application."
 license = "Unlicense"

--- a/src/game_input.rs
+++ b/src/game_input.rs
@@ -1,0 +1,35 @@
+use termion::event::Key;
+use termion::AsyncReader;
+
+use crate::Direction;
+
+#[derive(Debug, PartialEq)]
+pub enum KeyPress {
+    Direction(Direction),
+    Q,
+    P,
+    Other,
+    None,
+}
+
+// TODO: still need to figure out how to abstract this part properly
+pub struct GameInput {
+    pub input: termion::input::Keys<AsyncReader>,
+}
+
+impl GameInput {
+    pub fn get_keypress(&mut self) -> KeyPress {
+        match self.input.by_ref().last() {
+            Some(Ok(key)) => match key {
+                Key::Char('q') => KeyPress::Q,
+                Key::Char('p') => KeyPress::P,
+                Key::Up => KeyPress::Direction(Direction::Up),
+                Key::Down => KeyPress::Direction(Direction::Down),
+                Key::Left => KeyPress::Direction(Direction::Left),
+                Key::Right => KeyPress::Direction(Direction::Right),
+                _ => KeyPress::Other,
+            },
+            _ => KeyPress::None,
+        }
+    }
+}

--- a/src/game_input.rs
+++ b/src/game_input.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use termion::event::Key;
 use termion::AsyncReader;
 
@@ -5,7 +7,7 @@ use crate::Direction;
 
 #[derive(Debug, PartialEq)]
 pub enum KeyPress {
-    Direction(Direction),
+    ArrowKey(Direction),
     Q,
     P,
     Other,
@@ -15,21 +17,43 @@ pub enum KeyPress {
 // TODO: still need to figure out how to abstract this part properly
 pub struct GameInput {
     pub input: termion::input::Keys<AsyncReader>,
+    pub keybinds: HashMap<termion::event::Key, KeyPress>,
 }
 
 impl GameInput {
-    pub fn get_keypress(&mut self) -> KeyPress {
+    pub fn new(input: termion::input::Keys<AsyncReader>) -> Self {
+        Self {
+            input,
+            keybinds: Self::create_keybinds(),
+        }
+    }
+    fn create_keybinds() -> HashMap<termion::event::Key, KeyPress> {
+        let mut keybinds = HashMap::new();
+
+        // Insert Quit button
+        keybinds.insert(Key::Char('q'), KeyPress::Q);
+        keybinds.insert(Key::Char('Q'), KeyPress::Q);
+        // Insert Pause button
+        keybinds.insert(Key::Char('p'), KeyPress::P);
+        keybinds.insert(Key::Char('P'), KeyPress::P);
+        // Insert direction buttons
+        keybinds.insert(Key::Up, KeyPress::ArrowKey(Direction::Up));
+        keybinds.insert(Key::Down, KeyPress::ArrowKey(Direction::Down));
+        keybinds.insert(Key::Left, KeyPress::ArrowKey(Direction::Left));
+        keybinds.insert(Key::Right, KeyPress::ArrowKey(Direction::Right));
+
+        keybinds
+    }
+    pub fn get_keypress(&mut self) -> &KeyPress {
         match self.input.by_ref().last() {
-            Some(Ok(key)) => match key {
-                Key::Char('q') => KeyPress::Q,
-                Key::Char('p') => KeyPress::P,
-                Key::Up => KeyPress::Direction(Direction::Up),
-                Key::Down => KeyPress::Direction(Direction::Down),
-                Key::Left => KeyPress::Direction(Direction::Left),
-                Key::Right => KeyPress::Direction(Direction::Right),
-                _ => KeyPress::Other,
-            },
-            _ => KeyPress::None,
+            Some(result) => {
+                let key = result.unwrap();
+                match self.keybinds.contains_key(&key) {
+                    true => self.keybinds.get(&key).unwrap(),
+                    false => &KeyPress::Other,
+                }
+            }
+            None => &KeyPress::None,
         }
     }
 }

--- a/src/game_input.rs
+++ b/src/game_input.rs
@@ -3,13 +3,14 @@ use std::collections::HashMap;
 use termion::event::Key;
 use termion::AsyncReader;
 
+use crate::parser::MovementKeyScheme;
 use crate::Direction;
 
 #[derive(Debug, PartialEq)]
 pub enum KeyPress {
-    ArrowKey(Direction),
-    Q,
-    P,
+    DirectionKey(Direction),
+    Quit,
+    Pause,
     Other,
     None,
 }
@@ -21,29 +22,41 @@ pub struct GameInput {
 }
 
 impl GameInput {
-    pub fn new(input: termion::input::Keys<AsyncReader>) -> Self {
+    pub fn new(input: termion::input::Keys<AsyncReader>, key_scheme: MovementKeyScheme) -> Self {
         Self {
             input,
-            keybinds: Self::create_keybinds(),
+            keybinds: Self::create_keybinds(key_scheme),
         }
     }
-    fn create_keybinds() -> HashMap<termion::event::Key, KeyPress> {
+    fn create_keybinds(
+        movement_key_scheme: MovementKeyScheme,
+    ) -> HashMap<termion::event::Key, KeyPress> {
         let mut keybinds = HashMap::new();
 
         // Insert Quit button
-        keybinds.insert(Key::Char('q'), KeyPress::Q);
-        keybinds.insert(Key::Char('Q'), KeyPress::Q);
+        keybinds.insert(Key::Char('q'), KeyPress::Quit);
+        keybinds.insert(Key::Char('Q'), KeyPress::Quit);
         // Insert Pause button
-        keybinds.insert(Key::Char('p'), KeyPress::P);
-        keybinds.insert(Key::Char('P'), KeyPress::P);
+        keybinds.insert(Key::Char('p'), KeyPress::Pause);
+        keybinds.insert(Key::Char('P'), KeyPress::Pause);
         // Insert direction buttons
-        keybinds.insert(Key::Up, KeyPress::ArrowKey(Direction::Up));
-        keybinds.insert(Key::Down, KeyPress::ArrowKey(Direction::Down));
-        keybinds.insert(Key::Left, KeyPress::ArrowKey(Direction::Left));
-        keybinds.insert(Key::Right, KeyPress::ArrowKey(Direction::Right));
-
+        match movement_key_scheme {
+            MovementKeyScheme::Arrows => {
+                keybinds.insert(Key::Up, KeyPress::DirectionKey(Direction::Up));
+                keybinds.insert(Key::Down, KeyPress::DirectionKey(Direction::Down));
+                keybinds.insert(Key::Left, KeyPress::DirectionKey(Direction::Left));
+                keybinds.insert(Key::Right, KeyPress::DirectionKey(Direction::Right));
+            }
+            MovementKeyScheme::WSAD => {
+                keybinds.insert(Key::Char('w'), KeyPress::DirectionKey(Direction::Up));
+                keybinds.insert(Key::Char('s'), KeyPress::DirectionKey(Direction::Down));
+                keybinds.insert(Key::Char('a'), KeyPress::DirectionKey(Direction::Left));
+                keybinds.insert(Key::Char('d'), KeyPress::DirectionKey(Direction::Right));
+            }
+        }
         keybinds
     }
+
     pub fn get_keypress(&mut self) -> &KeyPress {
         match self.input.by_ref().last() {
             Some(result) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,22 +5,14 @@ use std::{thread, time::Duration};
 
 use clap::Parser;
 use rand::Rng;
-use termion::event::Key;
 use termion::input::TermRead;
 use termion::raw::{IntoRawMode, RawTerminal};
 use termion::screen::IntoAlternateScreen;
-use termion::{async_stdin, clear, color, cursor, terminal_size, AsyncReader};
+use termion::{async_stdin, clear, color, cursor, terminal_size};
 
+use game_input::KeyPress;
+mod game_input;
 mod parser;
-
-#[derive(Debug, PartialEq)]
-enum KeyPress {
-    Direction(Direction),
-    Q,
-    P,
-    Other,
-    None,
-}
 
 #[derive(Debug, PartialEq)]
 enum Direction {
@@ -28,28 +20,6 @@ enum Direction {
     Down,
     Left,
     Right,
-}
-
-// TODO: still need to figure out how to abstract this part properly
-struct GameInput {
-    input: termion::input::Keys<AsyncReader>,
-}
-
-impl GameInput {
-    fn get_keypress(&mut self) -> KeyPress {
-        match self.input.by_ref().last() {
-            Some(Ok(key)) => match key {
-                Key::Char('q') => KeyPress::Q,
-                Key::Char('p') => KeyPress::P,
-                Key::Up => KeyPress::Direction(Direction::Up),
-                Key::Down => KeyPress::Direction(Direction::Down),
-                Key::Left => KeyPress::Direction(Direction::Left),
-                Key::Right => KeyPress::Direction(Direction::Right),
-                _ => KeyPress::Other,
-            },
-            _ => KeyPress::None,
-        }
-    }
 }
 
 // TODO: still need to figure out how to abstract this part properly
@@ -155,7 +125,7 @@ struct Game {
     snake: VecDeque<GridCell>,
     food: GridCell,
     direction: Direction,
-    input: GameInput,
+    input: game_input::GameInput,
     output: GameOutput,
     min_width: u16,
     min_height: u16,
@@ -166,7 +136,7 @@ struct Game {
 
 impl Game {
     fn new(
-        input: GameInput,
+        input: game_input::GameInput,
         output: GameOutput,
         term_max_x: u16,
         term_max_y: u16,
@@ -386,7 +356,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let speed = args.speed.value();
 
     let mut game = Game::new(
-        GameInput { input },
+        game_input::GameInput { input },
         GameOutput { output },
         term_size.0,
         term_size.1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ impl Game {
             // Handle user input
             match self.input.get_keypress() {
                 // Pause the game
-                KeyPress::P => loop {
+                KeyPress::Pause => loop {
                     // Sleep here to let input thread have some control
                     thread::sleep(Duration::from_millis(10));
                     match self.input.get_keypress() {
@@ -296,18 +296,18 @@ impl Game {
                     }
                 },
                 // Quit the game
-                KeyPress::Q => break 'mainloop,
+                KeyPress::Quit => break 'mainloop,
                 // Get pressed direction key
-                KeyPress::ArrowKey(Direction::Up) if !self.direction.vertical() => {
+                KeyPress::DirectionKey(Direction::Up) if !self.direction.vertical() => {
                     self.direction = Direction::Up;
                 }
-                KeyPress::ArrowKey(Direction::Down) if !self.direction.vertical() => {
+                KeyPress::DirectionKey(Direction::Down) if !self.direction.vertical() => {
                     self.direction = Direction::Down;
                 }
-                KeyPress::ArrowKey(Direction::Left) if self.direction.vertical() => {
+                KeyPress::DirectionKey(Direction::Left) if self.direction.vertical() => {
                     self.direction = Direction::Left;
                 }
-                KeyPress::ArrowKey(Direction::Right) if self.direction.vertical() => {
+                KeyPress::DirectionKey(Direction::Right) if self.direction.vertical() => {
                     self.direction = Direction::Right;
                 }
                 _ => (),
@@ -351,7 +351,7 @@ impl Game {
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parser::ArgsParser::parse();
     let input = async_stdin().keys();
-    let input = game_input::GameInput::new(input);
+    let input = game_input::GameInput::new(input, args.movement_key_scheme);
     let output = stdout().into_raw_mode()?.into_alternate_screen()?;
 
     let term_size = terminal_size()?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,8 @@ pub struct ArgsParser {
     pub grid_size: GridSize,
     #[arg(short, long, value_enum, default_value_t = Speed::High)]
     pub speed: Speed,
+    #[arg(short, long, value_enum, default_value_t = MovementKeyScheme::Arrows)]
+    pub movement_key_scheme: MovementKeyScheme,
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -41,4 +43,10 @@ impl Speed {
             Speed::High => 60,
         }
     }
+}
+
+#[derive(ValueEnum, Clone, Debug, PartialEq)]
+pub enum MovementKeyScheme {
+    WSAD,
+    Arrows,
 }


### PR DESCRIPTION
This branch adds a keybindings data structure to the input handler. Also, some refactoring to separate code and rename stuff.
Currently only 2 keybindings are supported: Arrows and WSAD. 